### PR TITLE
feat: trip scheduling system — drivers list trips, passengers search them

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -10,6 +10,11 @@ BOOKINGS_COLLECTION = "bookings"
 PAYMENTS_COLLECTION = "payments"
 OTP_COLLECTION = "otps"
 NOTIFICATIONS_COLLECTION = "notifications"
+TRIPS_COLLECTION = "trips"
+REVIEWS_COLLECTION = "reviews"
+EARNINGS_COLLECTION = "earnings"
+DISPUTES_COLLECTION = "disputes"
+DISPUTE_MESSAGES_COLLECTION = "dispute_messages"
 
 
 class Database:

--- a/app/enums/common.py
+++ b/app/enums/common.py
@@ -53,3 +53,10 @@ class PaymentMethod(str, Enum):
     ONLINE = "online"
     CASH = "cash"
 
+
+class TripStatus(str, Enum):
+    SCHEDULED = "scheduled"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+

--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ from app.core.database import (
     BOOKINGS_COLLECTION,
     NOTIFICATIONS_COLLECTION,
     PAYMENTS_COLLECTION,
+    TRIPS_COLLECTION,
 )
 from app.core.exceptions import LaaRideException
 from app.core.firebase import setup_firebase
@@ -131,6 +132,12 @@ async def lifespan(app: FastAPI):
     await db_instance.db["disputes"].create_index("raised_by")
     await db_instance.db["disputes"].create_index("status")
     await db_instance.db["dispute_messages"].create_index("dispute_id")
+    # Trip indexes
+    await db_instance.db[TRIPS_COLLECTION].create_index("driver_id")
+    await db_instance.db[TRIPS_COLLECTION].create_index([("driver_id", 1), ("trip_date", -1)])
+    await db_instance.db[TRIPS_COLLECTION].create_index([("origin.name", 1), ("destination.name", 1), ("trip_date", 1)])
+    await db_instance.db[TRIPS_COLLECTION].create_index([("status", 1), ("trip_date", 1)])
+    await db_instance.db[TRIPS_COLLECTION].create_index("route_id")
 
     logger.info("indexes_created")
 

--- a/app/models/trip.py
+++ b/app/models/trip.py
@@ -1,0 +1,55 @@
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import Field
+
+from app.enums.common import TripStatus
+from app.models.base import MongoBaseDocument
+
+
+class TripDocument(MongoBaseDocument):
+    """MongoDB document for a driver-listed trip on a fixed route."""
+
+    # Core references
+    route_id: str = Field(..., description="Reference to Route")
+    driver_id: str = Field(..., description="Reference to Driver (user_id)")
+    vehicle_id: str = Field(..., description="Reference to Vehicle")
+
+    # Trip schedule
+    trip_date: date = Field(..., description="Date of the trip")
+    departure_time: str = Field(..., description="Departure time (HH:MM 24h)")
+
+    # Seat tracking
+    total_seats: int = Field(..., gt=0, description="Total seats in vehicle")
+    available_seats: int = Field(..., ge=0, description="Remaining bookable seats")
+    booked_seat_ids: list[str] = Field(
+        default_factory=list, description="Seat IDs already booked"
+    )
+
+    # Pricing
+    fare_per_seat: float = Field(..., gt=0, description="Fare per seat for this trip")
+
+    # Status
+    status: TripStatus = Field(default=TripStatus.SCHEDULED)
+
+    # Denormalized for fast lookups (avoids joins on search)
+    route_name: str = Field(default="", description="Cached route name")
+    origin: dict = Field(default_factory=dict, description="Origin {name, lat, lng}")
+    destination: dict = Field(
+        default_factory=dict, description="Destination {name, lat, lng}"
+    )
+    distance_km: Optional[float] = Field(None)
+    estimated_duration_mins: Optional[int] = Field(None)
+
+    # Denormalized driver info
+    driver_name: str = Field(default="", description="Driver display name")
+    driver_phone: str = Field(default="", description="Driver phone")
+    driver_rating: float = Field(default=0.0)
+
+    # Denormalized vehicle info
+    vehicle_number: str = Field(default="", description="Registration number")
+    vehicle_type: str = Field(default="")
+    vehicle_model: str = Field(default="")
+
+    # Notes
+    notes: Optional[str] = Field(None, description="Driver notes for this trip")

--- a/app/routes/v1/__init__.py
+++ b/app/routes/v1/__init__.py
@@ -14,6 +14,7 @@ from .tracking import router as tracking_router
 from .reviews import router as reviews_router
 from .earnings import router as earnings_router
 from .disputes import router as disputes_router
+from .trips import router as trips_router
 
 v1_router = APIRouter(prefix="/api/v1")
 
@@ -31,3 +32,4 @@ v1_router.include_router(tracking_router)
 v1_router.include_router(reviews_router, prefix="/reviews")
 v1_router.include_router(earnings_router, prefix="/earnings")
 v1_router.include_router(disputes_router, prefix="/disputes")
+v1_router.include_router(trips_router)

--- a/app/routes/v1/drivers.py
+++ b/app/routes/v1/drivers.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Query, status
 
 from app.core.database import get_database
 from app.core.security import get_current_active_user, get_current_admin, get_current_driver
-from app.enums.common import DriverStatus
+from app.enums.common import DriverStatus, TripStatus
 from app.models.user import UserDocument
 from app.schemas.driver import (
     AvailabilityToggle,
@@ -15,8 +15,9 @@ from app.schemas.driver import (
     DriverUpdate,
     SuspendRequest,
 )
+from app.schemas.trip import TripCreate, TripResponse, TripUpdate
 from app.schemas.vehicle import VehicleCreate, VehicleResponse, VehicleUpdate
-from app.services import driver_service
+from app.services import driver_service, trip_service
 
 router = APIRouter(tags=["Drivers"])
 
@@ -137,6 +138,69 @@ async def update_my_vehicle(
     return await driver_service.update_vehicle(
         str(current_user.id), vehicle_id, data, db
     )
+
+
+# ── Trip management ────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/me/trips",
+    response_model=TripResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new trip listing",
+)
+async def create_trip(
+    data: TripCreate,
+    current_user: UserDocument = Depends(get_current_driver),
+    db: Any = Depends(get_database),
+):
+    """Driver lists a new trip on a fixed route."""
+    return await trip_service.create_trip(str(current_user.id), data, db)
+
+
+@router.get(
+    "/me/trips",
+    summary="List own trips",
+)
+async def list_my_trips(
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
+    trip_status: Optional[TripStatus] = Query(default=None, alias="status"),
+    current_user: UserDocument = Depends(get_current_driver),
+    db: Any = Depends(get_database),
+):
+    """Paginated list of trips created by the current driver."""
+    return await trip_service.list_driver_trips(
+        str(current_user.id), skip, limit, db, trip_status=trip_status
+    )
+
+
+@router.put(
+    "/me/trips/{trip_id}",
+    response_model=TripResponse,
+    summary="Update a trip",
+)
+async def update_my_trip(
+    trip_id: str,
+    data: TripUpdate,
+    current_user: UserDocument = Depends(get_current_driver),
+    db: Any = Depends(get_database),
+):
+    """Update departure time, fare, notes, or status of a trip you own."""
+    return await trip_service.update_trip(trip_id, str(current_user.id), data, db)
+
+
+@router.delete(
+    "/me/trips/{trip_id}",
+    summary="Cancel a trip",
+)
+async def cancel_my_trip(
+    trip_id: str,
+    current_user: UserDocument = Depends(get_current_driver),
+    db: Any = Depends(get_database),
+):
+    """Cancel a scheduled trip."""
+    return await trip_service.cancel_trip(trip_id, str(current_user.id), db)
 
 
 # ── Admin routes ───────────────────────────────────────────────────────────

--- a/app/routes/v1/payments.py
+++ b/app/routes/v1/payments.py
@@ -32,6 +32,16 @@ async def initiate_payment(
     return await payment_service.initiate_payment(str(current_user.id), request, db)
 
 
+@router.post("/create-order", response_model=InitiatePaymentResponse)
+async def create_order(
+    request: InitiatePaymentRequest,
+    current_user: UserDocument = Depends(get_current_user),
+    db: Any = Depends(get_database),
+):
+    """Alias for /initiate — create a Razorpay order for a confirmed booking."""
+    return await payment_service.initiate_payment(str(current_user.id), request, db)
+
+
 @router.post("/verify", response_model=VerifyPaymentResponse)
 async def verify_payment(
     request: VerifyPaymentRequest,

--- a/app/routes/v1/search.py
+++ b/app/routes/v1/search.py
@@ -77,3 +77,28 @@ async def popular_origins(
 ):
     """Top origin cities ranked by booking count."""
     return await search_service.get_popular_origins(db)
+
+
+@router.get("/trips", summary="Search trips (passenger-facing)")
+async def search_trips(
+    origin: Optional[str] = Query(default=None, description="Origin city name"),
+    destination: Optional[str] = Query(default=None, description="Destination city name"),
+    date: Optional[date] = Query(default=None, description="Travel date (YYYY-MM-DD)"),
+    seats: Optional[int] = Query(default=None, ge=1, description="Minimum seats required"),
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
+    db: Any = Depends(get_database),
+):
+    """
+    Primary passenger search — returns driver-listed trips matching filters.
+    Results include driver info, vehicle info, available seats, and fare per seat.
+    """
+    return await search_service.search_trips_for_passengers(
+        db,
+        origin=origin,
+        destination=destination,
+        trip_date=date,
+        seats=seats,
+        skip=skip,
+        limit=limit,
+    )

--- a/app/routes/v1/trips.py
+++ b/app/routes/v1/trips.py
@@ -1,0 +1,38 @@
+"""Trip endpoints — public seat map and search."""
+
+from datetime import date
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from app.core.database import get_database
+from app.schemas.trip import SeatMapResponse, TripResponse
+from app.services import trip_service
+
+router = APIRouter(prefix="/trips", tags=["Trips"])
+
+
+@router.get(
+    "/{trip_id}",
+    response_model=TripResponse,
+    summary="Get trip details",
+)
+async def get_trip(
+    trip_id: str,
+    db: Any = Depends(get_database),
+):
+    """Return full trip details including driver and vehicle info."""
+    return await trip_service.get_trip_by_id(trip_id, db)
+
+
+@router.get(
+    "/{trip_id}/seats",
+    response_model=SeatMapResponse,
+    summary="Get seat map for a trip",
+)
+async def get_trip_seats(
+    trip_id: str,
+    db: Any = Depends(get_database),
+):
+    """Return seat availability and layout for a trip."""
+    return await trip_service.get_trip_seat_map(trip_id, db)

--- a/app/routes/v1/users.py
+++ b/app/routes/v1/users.py
@@ -1,13 +1,18 @@
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, File, Query, UploadFile, status
+from pydantic import BaseModel
 
 from app.core.database import get_database
 from app.core.security import get_current_active_user, get_current_admin
 from app.enums.common import UserRole
 from app.models.user import UserDocument
 from app.schemas.user import UserResponse, UserUpdate
-from app.services import user_service
+from app.services import notification_service, user_service
+
+
+class FcmTokenRequest(BaseModel):
+    token: str
 
 router = APIRouter(tags=["Users"])
 
@@ -58,6 +63,20 @@ async def get_my_bookings(
     return await user_service.get_user_booking_history(
         str(current_user.id), skip, limit, db
     )
+
+
+@router.post(
+    "/me/fcm-token",
+    summary="Register FCM push notification token",
+    status_code=status.HTTP_200_OK,
+)
+async def register_fcm_token(
+    data: FcmTokenRequest,
+    current_user: UserDocument = Depends(get_current_active_user),
+    db: Any = Depends(get_database),
+):
+    """Register or refresh an FCM token for push notifications."""
+    return await notification_service.register_fcm_token(str(current_user.id), data.token, db)
 
 
 @router.delete("/me", summary="Deactivate account")

--- a/app/schemas/trip.py
+++ b/app/schemas/trip.py
@@ -1,0 +1,89 @@
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+from app.enums.common import TripStatus
+
+
+class TripCreate(BaseModel):
+    """Payload to create a new trip listing."""
+
+    route_id: str = Field(..., description="Route to operate on")
+    vehicle_id: str = Field(..., description="Vehicle to use")
+    trip_date: date = Field(..., description="Date of the trip (YYYY-MM-DD)")
+    departure_time: str = Field(
+        ...,
+        pattern=r"^\d{2}:\d{2}$",
+        description="Departure time in HH:MM (24-hour)",
+    )
+    fare_per_seat: float = Field(..., gt=0, description="Fare charged per seat")
+    notes: Optional[str] = Field(None, description="Optional driver notes")
+
+    @field_validator("trip_date")
+    @classmethod
+    def date_not_in_past(cls, v: date) -> date:
+        if v < date.today():
+            raise ValueError("trip_date cannot be in the past")
+        return v
+
+
+class TripUpdate(BaseModel):
+    """Partial update for a trip."""
+
+    departure_time: Optional[str] = Field(None, pattern=r"^\d{2}:\d{2}$")
+    fare_per_seat: Optional[float] = Field(None, gt=0)
+    notes: Optional[str] = None
+    status: Optional[TripStatus] = None
+
+
+class TripResponse(BaseModel):
+    """Full trip detail returned to clients."""
+
+    id: Optional[str] = Field(None, alias="_id")
+    route_id: str
+    driver_id: str
+    vehicle_id: str
+    trip_date: date
+    departure_time: str
+    total_seats: int
+    available_seats: int
+    booked_seat_ids: list[str] = []
+    fare_per_seat: float
+    status: TripStatus
+    route_name: str
+    origin: dict
+    destination: dict
+    distance_km: Optional[float] = None
+    estimated_duration_mins: Optional[int] = None
+    driver_name: str = ""
+    driver_phone: str = ""
+    driver_rating: float = 0.0
+    vehicle_number: str = ""
+    vehicle_type: str = ""
+    vehicle_model: str = ""
+    notes: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"populate_by_name": True}
+
+
+class TripSearchParams(BaseModel):
+    """Query parameters for trip search."""
+
+    origin: Optional[str] = None
+    destination: Optional[str] = None
+    date: Optional[date] = None
+    seats: Optional[int] = Field(None, ge=1)
+
+
+class SeatMapResponse(BaseModel):
+    """Seat availability for a trip."""
+
+    trip_id: str
+    vehicle_id: str
+    total_seats: int
+    available_seats: int
+    booked_seat_ids: list[str]
+    seat_layout: list[dict] = []

--- a/app/services/search_service.py
+++ b/app/services/search_service.py
@@ -12,15 +12,18 @@ from app.core.database import (
     BOOKINGS_COLLECTION,
     DRIVERS_COLLECTION,
     ROUTES_COLLECTION,
+    TRIPS_COLLECTION,
     VEHICLES_COLLECTION,
 )
 from app.enums.common import (
     AvailabilityStatus,
     BookingStatus,
     DriverStatus,
+    TripStatus,
     VehicleType,
 )
 from app.schemas.route import RouteResponse
+from app.schemas.trip import TripResponse
 from app.services.osrm_service import get_route_info
 
 logger = logging.getLogger(__name__)
@@ -475,3 +478,47 @@ async def get_trip_summary(route_id: str, trip_date: date, db: Any) -> dict:
         "is_peak_season": is_peak_season,
         "weather_advisory": weather_advisory,
     }
+
+
+# ── 8. Search Trips (frontend primary search) ─────────────────────────────
+
+
+async def search_trips_for_passengers(
+    db: Any,
+    origin: Optional[str] = None,
+    destination: Optional[str] = None,
+    trip_date: Optional[date] = None,
+    seats: Optional[int] = None,
+    skip: int = 0,
+    limit: int = 20,
+) -> dict:
+    """
+    Search driver-listed trips by origin, destination, date and seat availability.
+    This is the primary passenger-facing search — returns TripResponse objects.
+    """
+    query: dict = {"status": TripStatus.SCHEDULED}
+
+    if origin:
+        query["origin.name"] = {"$regex": origin, "$options": "i"}
+    if destination:
+        query["destination.name"] = {"$regex": destination, "$options": "i"}
+    if trip_date:
+        query["trip_date"] = trip_date.isoformat()
+    if seats:
+        query["available_seats"] = {"$gte": seats}
+
+    total = await db[TRIPS_COLLECTION].count_documents(query)
+    cursor = (
+        db[TRIPS_COLLECTION]
+        .find(query)
+        .sort([("trip_date", 1), ("departure_time", 1)])
+        .skip(skip)
+        .limit(limit)
+    )
+    trips = [TripResponse(**doc).model_dump() async for doc in cursor]
+    # Ensure _id is serialised as string
+    for t in trips:
+        if t.get("id") is None and t.get("_id"):
+            t["id"] = str(t["_id"])
+
+    return {"data": trips, "total": total, "skip": skip, "limit": limit}

--- a/app/services/trip_service.py
+++ b/app/services/trip_service.py
@@ -1,0 +1,255 @@
+"""Trip service — business logic for driver-listed trips."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Optional
+
+from bson import ObjectId, errors
+from fastapi import HTTPException, status
+
+from app.core.database import (
+    DRIVERS_COLLECTION,
+    ROUTES_COLLECTION,
+    TRIPS_COLLECTION,
+    VEHICLES_COLLECTION,
+)
+from app.enums.common import TripStatus
+from app.schemas.trip import SeatMapResponse, TripCreate, TripResponse, TripUpdate
+
+
+def _to_object_id(value: str, label: str = "ID") -> ObjectId:
+    try:
+        return ObjectId(value)
+    except errors.InvalidId:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid {label} format",
+        )
+
+
+def _doc_to_response(doc: dict) -> TripResponse:
+    return TripResponse(**doc)
+
+
+# ── Create ─────────────────────────────────────────────────────────────────
+
+
+async def create_trip(driver_user_id: str, data: TripCreate, db: Any) -> TripResponse:
+    """Driver creates a new trip listing for a fixed route."""
+    # Validate route
+    route = await db[ROUTES_COLLECTION].find_one(
+        {"_id": _to_object_id(data.route_id, "Route ID"), "is_active": True}
+    )
+    if not route:
+        raise HTTPException(status_code=404, detail="Route not found or inactive")
+
+    # Validate vehicle belongs to this driver
+    vehicle = await db[VEHICLES_COLLECTION].find_one(
+        {
+            "_id": _to_object_id(data.vehicle_id, "Vehicle ID"),
+            "driver_id": driver_user_id,
+            "is_active": True,
+        }
+    )
+    if not vehicle:
+        raise HTTPException(status_code=404, detail="Vehicle not found or not owned by driver")
+
+    # Prevent duplicate trip (same driver, route, vehicle, date, time)
+    existing = await db[TRIPS_COLLECTION].find_one(
+        {
+            "driver_id": driver_user_id,
+            "route_id": data.route_id,
+            "trip_date": data.trip_date.isoformat(),
+            "departure_time": data.departure_time,
+            "status": {"$nin": [TripStatus.CANCELLED]},
+        }
+    )
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail="A trip for this route, date, and departure time already exists",
+        )
+
+    # Fetch driver info for denormalization
+    driver = await db[DRIVERS_COLLECTION].find_one({"user_id": driver_user_id})
+    driver_name = driver.get("full_name", "") if driver else ""
+    driver_phone = driver.get("phone", "") if driver else ""
+    driver_rating = driver.get("rating", 0.0) if driver else 0.0
+
+    total_seats = vehicle.get("capacity", 4)
+    now = datetime.utcnow()
+
+    doc = {
+        "route_id": data.route_id,
+        "driver_id": driver_user_id,
+        "vehicle_id": data.vehicle_id,
+        "trip_date": data.trip_date.isoformat(),
+        "departure_time": data.departure_time,
+        "total_seats": total_seats,
+        "available_seats": total_seats,
+        "booked_seat_ids": [],
+        "fare_per_seat": data.fare_per_seat,
+        "status": TripStatus.SCHEDULED,
+        "route_name": route.get("name", ""),
+        "origin": route.get("origin", {}),
+        "destination": route.get("destination", {}),
+        "distance_km": route.get("distance_km"),
+        "estimated_duration_mins": route.get("estimated_duration_mins"),
+        "driver_name": driver_name,
+        "driver_phone": driver_phone,
+        "driver_rating": driver_rating,
+        "vehicle_number": vehicle.get("registration_number", ""),
+        "vehicle_type": vehicle.get("vehicle_type", ""),
+        "vehicle_model": vehicle.get("model", ""),
+        "notes": data.notes,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    result = await db[TRIPS_COLLECTION].insert_one(doc)
+    doc["_id"] = result.inserted_id
+    return _doc_to_response(doc)
+
+
+# ── List driver trips ──────────────────────────────────────────────────────
+
+
+async def list_driver_trips(
+    driver_user_id: str,
+    skip: int,
+    limit: int,
+    db: Any,
+    trip_status: Optional[TripStatus] = None,
+) -> dict:
+    """Return paginated trips listed by a driver."""
+    query: dict = {"driver_id": driver_user_id}
+    if trip_status:
+        query["status"] = trip_status
+
+    total = await db[TRIPS_COLLECTION].count_documents(query)
+    cursor = (
+        db[TRIPS_COLLECTION]
+        .find(query)
+        .sort("trip_date", -1)
+        .skip(skip)
+        .limit(limit)
+    )
+    trips = [_doc_to_response(doc) async for doc in cursor]
+    return {"data": trips, "total": total, "skip": skip, "limit": limit}
+
+
+# ── Get single trip ────────────────────────────────────────────────────────
+
+
+async def get_trip_by_id(trip_id: str, db: Any) -> TripResponse:
+    oid = _to_object_id(trip_id, "Trip ID")
+    doc = await db[TRIPS_COLLECTION].find_one({"_id": oid})
+    if not doc:
+        raise HTTPException(status_code=404, detail="Trip not found")
+    return _doc_to_response(doc)
+
+
+# ── Update trip ────────────────────────────────────────────────────────────
+
+
+async def update_trip(
+    trip_id: str, driver_user_id: str, data: TripUpdate, db: Any
+) -> TripResponse:
+    oid = _to_object_id(trip_id, "Trip ID")
+    doc = await db[TRIPS_COLLECTION].find_one({"_id": oid, "driver_id": driver_user_id})
+    if not doc:
+        raise HTTPException(status_code=404, detail="Trip not found or not owned by driver")
+
+    if doc["status"] == TripStatus.COMPLETED:
+        raise HTTPException(status_code=400, detail="Cannot update a completed trip")
+
+    fields = data.model_dump(exclude_unset=True)
+    fields["updated_at"] = datetime.utcnow()
+
+    await db[TRIPS_COLLECTION].update_one({"_id": oid}, {"$set": fields})
+    updated = await db[TRIPS_COLLECTION].find_one({"_id": oid})
+    return _doc_to_response(updated)
+
+
+# ── Cancel trip ────────────────────────────────────────────────────────────
+
+
+async def cancel_trip(trip_id: str, driver_user_id: str, db: Any) -> dict:
+    oid = _to_object_id(trip_id, "Trip ID")
+    doc = await db[TRIPS_COLLECTION].find_one({"_id": oid, "driver_id": driver_user_id})
+    if not doc:
+        raise HTTPException(status_code=404, detail="Trip not found or not owned by driver")
+
+    if doc["status"] in (TripStatus.COMPLETED, TripStatus.CANCELLED):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Trip is already {doc['status']}",
+        )
+
+    await db[TRIPS_COLLECTION].update_one(
+        {"_id": oid},
+        {"$set": {"status": TripStatus.CANCELLED, "updated_at": datetime.utcnow()}},
+    )
+    return {"message": "Trip cancelled successfully"}
+
+
+# ── Seat map ───────────────────────────────────────────────────────────────
+
+
+async def get_trip_seat_map(trip_id: str, db: Any) -> SeatMapResponse:
+    """Return seat availability for a trip."""
+    oid = _to_object_id(trip_id, "Trip ID")
+    doc = await db[TRIPS_COLLECTION].find_one({"_id": oid})
+    if not doc:
+        raise HTTPException(status_code=404, detail="Trip not found")
+
+    # Fetch seat layout from vehicle
+    vehicle = await db[VEHICLES_COLLECTION].find_one(
+        {"_id": _to_object_id(doc["vehicle_id"], "Vehicle ID")}
+    )
+    seat_layout = vehicle.get("seat_layout", []) if vehicle else []
+
+    return SeatMapResponse(
+        trip_id=str(doc["_id"]),
+        vehicle_id=doc["vehicle_id"],
+        total_seats=doc["total_seats"],
+        available_seats=doc["available_seats"],
+        booked_seat_ids=doc.get("booked_seat_ids", []),
+        seat_layout=seat_layout,
+    )
+
+
+# ── Search trips ───────────────────────────────────────────────────────────
+
+
+async def search_trips(
+    origin: Optional[str],
+    destination: Optional[str],
+    trip_date: Optional[date],
+    seats: Optional[int],
+    skip: int,
+    limit: int,
+    db: Any,
+) -> dict:
+    """Search available trips by origin, destination, date, and seat count."""
+    query: dict = {"status": TripStatus.SCHEDULED}
+
+    if origin:
+        query["origin.name"] = {"$regex": origin, "$options": "i"}
+    if destination:
+        query["destination.name"] = {"$regex": destination, "$options": "i"}
+    if trip_date:
+        query["trip_date"] = trip_date.isoformat()
+    if seats:
+        query["available_seats"] = {"$gte": seats}
+
+    total = await db[TRIPS_COLLECTION].count_documents(query)
+    cursor = (
+        db[TRIPS_COLLECTION]
+        .find(query)
+        .sort([("trip_date", 1), ("departure_time", 1)])
+        .skip(skip)
+        .limit(limit)
+    )
+    trips = [_doc_to_response(doc) async for doc in cursor]
+    return {"data": trips, "total": total, "skip": skip, "limit": limit}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Trip entity** — `TripDocument` model + `TripCreate` / `TripResponse` / `SeatMapResponse` schemas. Drivers pre-list trips on fixed routes with date, departure time, fare per seat, and vehicle.
- **Trip service** — full CRUD: create, list (paginated), update, cancel, seat-map lookup, and passenger-facing search.
- **Driver trip endpoints** — `POST/GET /api/v1/drivers/me/trips`, `PUT/DELETE /api/v1/drivers/me/trips/{id}`
- **Public trip endpoints** — `GET /api/v1/trips/{id}` (detail) and `GET /api/v1/trips/{id}/seats` (seat map with vehicle layout)
- **Passenger search** — `GET /api/v1/search/trips?origin=&destination=&date=&seats=` returns `TripResponse` objects with driver name/rating, vehicle info, available seats, and fare per seat — this is the primary booking flow entry point the frontend needs
- **FCM token endpoint** — `POST /api/v1/users/me/fcm-token` to register push notification tokens
- **Payment alias** — `POST /api/v1/payments/create-order` mirrors `/payments/initiate`
- **`TripStatus` enum** — `scheduled / in_progress / completed / cancelled`
- **5 MongoDB indexes** on the trips collection for fast date/origin/destination queries

## Test plan

- [ ] Driver can create a trip (`POST /drivers/me/trips`) — validates route active, vehicle owned, no duplicate
- [ ] Driver can list/update/cancel their trips
- [ ] `GET /trips/{id}/seats` returns correct `available_seats` and seat layout
- [ ] `GET /search/trips?origin=Leh&destination=Kargil&date=2026-04-01&seats=2` returns matching scheduled trips
- [ ] `POST /users/me/fcm-token` registers token without duplicate
- [ ] `POST /payments/create-order` behaves identically to `/payments/initiate`

https://claude.ai/code/session_01XLd1EiiGja9HyBSSmxc9w4
EOF
)